### PR TITLE
Remove references to using these as interview questions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The primary goal of this list is to collect some crazy examples and explain how 
 
 If you are a beginner, you can use this notes to get deeper dive into the JavaScript. I hope this notes will motivate you to spend more time reading the specification.
 
-If you are a professional developer, you can consider these examples as a great resource for interview questions and quizzes for newcomers in your company. At the same time, these examples would be handy while preparing for the interview.
+If you are a professional developer, you can consider these examples as a great reference for all of the quirks and unexpected edges of our beloved JavaScript.
 
 In any case, just read this. Probably you're going to find something new for yourself.
 


### PR DESCRIPTION
Thanks for building & sharing this compendium of JavaScript factoids 🤓

Quizzing folks for esoteric JavaScript knowledge is not likely to help find talent that solves real-world problems. Similar to whiteboard exercises, these kinds of quizzes do not contribute to understanding how an applicant really solves problems or works with others. Just a few links to read about this topic:

  * https://hired.com/blog/employers/whiteboard-interview-alternatives/
  * https://theoutline.com/post/1166/programmers-are-confessing-their-coding-sins-to-protest-a-broken-job-interview-process
  * https://medium.com/square-corner-blog/why-we-pair-interview-c2ab4b599bd7

Proposing this change to help people avoid this kind of interview foible.