### PR TITLE
Fixed typo in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Original idea of WTFJS belongs to [Brian Leroux](https://twitter.com/brianleroux
   - [Object as a key of object's property](#object-as-a-key-of-objects-property)
   - [Accessing prototypes with `__proto__`](#accessing-prototypes-with-__proto__)
   - [``` `${{Object}}` ```](#-object-)
-  - [Destructoring with default values](#destructoring-with-default-values)
+  - [Destructuring with default values](#destructuring-with-default-values)
   - [Dots and spreading](#dots-and-spreading)
   - [Labels](#labels)
   - [Nested labels](#nested-labels)


### PR DESCRIPTION
Fixed typo in 'Destructuring with default values' heading in table of contents as it wasn't linking correctly