### PR TITLE
updated explanation for why {} + [] differs from [] + {}

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,7 +843,7 @@ What about other examples? A `ToPrimitive` and `ToString` methods are being impl
 
 Notably, `{} + []` here is the exception. The reason why it differs from `[] + {}` is that, without parenthesis, it is interpreted as a code block and then a unary +, converting `[]` into a number. It sees the following:
 
-```
+```js 
 {
   // a code block here
 }
@@ -852,8 +852,8 @@ Notably, `{} + []` here is the exception. The reason why it differs from `[] + {
 
 To get the same output as `[] + {}` we can wrap it in parenthesis.
 
-```
-({} + []) -> [object Object]
+```js
+({} + []) // -> [object Object]
 ```
 
 ## Addition of RegExps

--- a/README.md
+++ b/README.md
@@ -841,6 +841,18 @@ What about other examples? A `ToPrimitive` and `ToString` methods are being impl
 - [**7.1.1** ToPrimitive(`input` [,`PreferredType`])](https://www.ecma-international.org/ecma-262/#sec-toprimitive)
 - [**7.1.12** ToString(`argument`)](https://www.ecma-international.org/ecma-262/#sec-tostring)
 
+Notably, `{} + []` here is the exception. The reason why it differs from `[] + {}` is that, without parenthesis, it is interpreted as a code block and then a unary +, converting `[]` into a number. It sees the following:
+```
+{
+  // a code block here
+}
++[] // -> 0
+```
+To get the same output as `[] + {}` we can wrap it in parenthesis.
+```
+({} + []) -> [object Object]
+```
+
 ## Addition of RegExps
 
 Did you know you can add numbers like this?

--- a/README.md
+++ b/README.md
@@ -842,13 +842,16 @@ What about other examples? A `ToPrimitive` and `ToString` methods are being impl
 - [**7.1.12** ToString(`argument`)](https://www.ecma-international.org/ecma-262/#sec-tostring)
 
 Notably, `{} + []` here is the exception. The reason why it differs from `[] + {}` is that, without parenthesis, it is interpreted as a code block and then a unary +, converting `[]` into a number. It sees the following:
+
 ```
 {
   // a code block here
 }
 +[] // -> 0
 ```
+
 To get the same output as `[] + {}` we can wrap it in parenthesis.
+
 ```
 ({} + []) -> [object Object]
 ```


### PR DESCRIPTION
It is not a case of concatenation, but rather `{}` being interpreted as a code block rather than an empty object.