### PR TITLE
Fix grammatical issues from Korean translation

### DIFF
--- a/README-kr.md
+++ b/README-kr.md
@@ -1,15 +1,15 @@
-# 아니 X 발? 자바스크립트 이게 뭐야??
+# 아니 X발? 자바스크립트 이게 뭐야??
 
 [![WTFPL 2.0][license-image]][license-url]
 [![NPM version][npm-image]][npm-url]
 
 > 재미있고 교묘한 JavaScript 예제
 
-JavaScript 는 훌륭한 언어입니다. JavaScript 는 구문이 단순하며 큰 생태계를 가지고 있습니다. 가장 중요한 점은 훌륭한 공동체를 가지고 있다는 것입니다.
+JavaScript는 훌륭한 언어입니다. JavaScript는 구문이 단순하며 큰 생태계를 가지고 있습니다. 가장 중요한 점은 훌륭한 공동체를 가지고 있다는 것입니다.
 
-동시에, 우리 모두는 자바스크립트가 까다로운 부분을 가진 꽤 재미있는 언어라는 것을 알고 있습니다. 몇몇 특징은 우리의 일상적인 일을 순식간에 지옥으로 바꾸기도 하고, 우리를 크게 웃게 만들기도 합니다.
+동시에, 우리 모두는 JavaScript가 까다로운 부분을 가진 꽤 재미있는 언어라는 것을 알고 있습니다. 몇몇 특징은 우리의 일상적인 일을 순식간에 지옥으로 바꾸기도 하고, 우리를 크게 웃게 만들기도 합니다.
 
-WTFJS 의 아이디어는 [Brian Leroux](https://twitter.com/brianleroux)에 속해있습니다. 이 목록들은 그의 이야기에서 꽤 영감을 받았습니다. [**“WTFJS”** at dotJS 2012](https://www.youtube.com/watch?v=et8xNAc2ic8):
+WTFJS의 아이디어는 [Brian Leroux](https://twitter.com/brianleroux)에 속해있습니다. 이 목록들은 그의 이야기에서 꽤 영감을 받았습니다. [**“WTFJS”** at dotJS 2012](https://www.youtube.com/watch?v=et8xNAc2ic8):
 
 [![dotJS 2012 - Brian Leroux - WTFJS](https://img.youtube.com/vi/et8xNAc2ic8/0.jpg)](https://www.youtube.com/watch?v=et8xNAc2ic8)
 
@@ -27,7 +27,7 @@ $ npm install -g wtfjs
 
 # 번역
 
-현재, **wtfjs**는 아래와 같은 언어로 번역되었습니다.:
+현재, **wtfjs**는 아래와 같은 언어로 번역되었습니다:
 
 - [中文版](./README-zh-cn.md)
 - [हिंदी](./README-hi.md)
@@ -51,14 +51,14 @@ $ npm install -g wtfjs
 - [✍🏻 표기법](#-%ED%91%9C%EA%B8%B0%EB%B2%95)
 - [👀 예제](#-%EC%98%88%EC%A0%9C)
   - [`[]`와 `![]은 같다`](#%EC%99%80-%EC%9D%80-%EA%B0%99%EB%8B%A4)
-  - [`true`는 `![]`와 같지 않지만, `[]` 이와도 같지 않다](#true%EB%8A%94-%EC%99%80-%EA%B0%99%EC%A7%80-%EC%95%8A%EC%A7%80%EB%A7%8C--%EC%9D%B4%EC%99%80%EB%8F%84-%EA%B0%99%EC%A7%80-%EC%95%8A%EB%8B%A4)
-  - [true 은 false](#true-%EC%9D%80-false)
+  - [`true`는 `![]`와 같지 않지만, `[]`와도 같지 않다](#true%EB%8A%94-%EC%99%80-%EA%B0%99%EC%A7%80-%EC%95%8A%EC%A7%80%EB%A7%8C-%EC%99%80%EB%8F%84-%EA%B0%99%EC%A7%80-%EC%95%8A%EB%8B%A4)
+  - [true는 false](#true%EB%8A%94-false)
   - [baNaNa](#banana)
   - [`NaN`은 `NaN`이 아니다](#nan%EC%9D%80-nan%EC%9D%B4-%EC%95%84%EB%8B%88%EB%8B%A4)
   - [이것은 실패다](#%EC%9D%B4%EA%B2%83%EC%9D%80-%EC%8B%A4%ED%8C%A8%EB%8B%A4)
   - [`[]`은 truthy 이지만 `true`는 아니다](#%EC%9D%80-truthy-%EC%9D%B4%EC%A7%80%EB%A7%8C-true%EB%8A%94-%EC%95%84%EB%8B%88%EB%8B%A4)
   - [`null`은 falsy 이지만 `false`은 아니다](#null%EC%9D%80-falsy-%EC%9D%B4%EC%A7%80%EB%A7%8C-false%EC%9D%80-%EC%95%84%EB%8B%88%EB%8B%A4)
-  - [`document.all`은 객체이지만 `undefined` 이다](#documentall%EC%9D%80-%EA%B0%9D%EC%B2%B4%EC%9D%B4%EC%A7%80%EB%A7%8C-undefined-%EC%9D%B4%EB%8B%A4)
+  - [`document.all`은 객체이지만 `undefined`이다](#documentall%EC%9D%80-%EA%B0%9D%EC%B2%B4%EC%9D%B4%EC%A7%80%EB%A7%8C-undefined%EC%9D%B4%EB%8B%A4)
   - [최소 값은 0 보다 크다](#%EC%B5%9C%EC%86%8C-%EA%B0%92%EC%9D%80-0-%EB%B3%B4%EB%8B%A4-%ED%81%AC%EB%8B%A4)
   - [함수는 함수가 아니다](#%ED%95%A8%EC%88%98%EB%8A%94-%ED%95%A8%EC%88%98%EA%B0%80-%EC%95%84%EB%8B%88%EB%8B%A4)
   - [배열 추가](#%EB%B0%B0%EC%97%B4-%EC%B6%94%EA%B0%80)
@@ -67,7 +67,7 @@ $ npm install -g wtfjs
   - [`undefined`과 `Number`](#undefined%EA%B3%BC-number)
   - [`parseInt`은 나쁜 놈이다](#parseint%EC%9D%80-%EB%82%98%EC%81%9C-%EB%86%88%EC%9D%B4%EB%8B%A4)
   - [`true`와 `false`를 이용한 수학](#true%EC%99%80-false%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EC%88%98%ED%95%99)
-  - [HTML 주석은 JavaScript 에서도 유효하다](#html-%EC%A3%BC%EC%84%9D%EC%9D%80-javascript-%EC%97%90%EC%84%9C%EB%8F%84-%EC%9C%A0%ED%9A%A8%ED%95%98%EB%8B%A4)
+  - [HTML 주석은 JavaScript에서도 유효하다](#html-%EC%A3%BC%EC%84%9D%EC%9D%80-javascript%EC%97%90%EC%84%9C%EB%8F%84-%EC%9C%A0%ED%9A%A8%ED%95%98%EB%8B%A4)
   - [`NaN`은 숫자가 아니다](#nan%EC%9D%80-%EC%88%AB%EC%9E%90%EA%B0%80-%EC%95%84%EB%8B%88%EB%8B%A4)
   - [`[]`과 `null`은 객체이다](#%EA%B3%BC-null%EC%9D%80-%EA%B0%9D%EC%B2%B4%EC%9D%B4%EB%8B%A4)
   - [마법처럼 증가하는 숫자](#%EB%A7%88%EB%B2%95%EC%B2%98%EB%9F%BC-%EC%A6%9D%EA%B0%80%ED%95%98%EB%8A%94-%EC%88%AB%EC%9E%90)
@@ -77,14 +77,14 @@ $ npm install -g wtfjs
   - [재미있는 수학](#%EC%9E%AC%EB%AF%B8%EC%9E%88%EB%8A%94-%EC%88%98%ED%95%99)
   - [RegExps 추가](#regexps-%EC%B6%94%EA%B0%80)
   - [문자열은 `String`의 인스턴스가 아니다](#%EB%AC%B8%EC%9E%90%EC%97%B4%EC%9D%80-string%EC%9D%98-%EC%9D%B8%EC%8A%A4%ED%84%B4%EC%8A%A4%EA%B0%80-%EC%95%84%EB%8B%88%EB%8B%A4)
-  - [backticks 으로 함수 호출](#backticks-%EC%9C%BC%EB%A1%9C-%ED%95%A8%EC%88%98-%ED%98%B8%EC%B6%9C)
+  - [backticks으로 함수 호출](#backticks%EC%9C%BC%EB%A1%9C-%ED%95%A8%EC%88%98-%ED%98%B8%EC%B6%9C)
   - [Call call call](#call-call-call)
   - [`constructor` 속성](#constructor-%EC%86%8D%EC%84%B1)
   - [객체 속성의 키로서의 객체](#%EA%B0%9D%EC%B2%B4-%EC%86%8D%EC%84%B1%EC%9D%98-%ED%82%A4%EB%A1%9C%EC%84%9C%EC%9D%98-%EA%B0%9D%EC%B2%B4)
   - [`__proto__`을 사용한 프로토 타입 접근](#__proto__%EC%9D%84-%EC%82%AC%EC%9A%A9%ED%95%9C-%ED%94%84%EB%A1%9C%ED%86%A0-%ED%83%80%EC%9E%85-%EC%A0%91%EA%B7%BC)
   - [`` `${{Object}}` ``](#-object-)
   - [디폴트 값으로 구조 해제](#%EB%94%94%ED%8F%B4%ED%8A%B8-%EA%B0%92%EC%9C%BC%EB%A1%9C-%EA%B5%AC%EC%A1%B0-%ED%95%B4%EC%A0%9C)
-  - [Dots 과 spreading](#dots-%EA%B3%BC-spreading)
+  - [Dots와 spreading](#dots%EC%99%80-spreading)
   - [라벨](#%EB%9D%BC%EB%B2%A8)
   - [중첩된 라벨들](#%EC%A4%91%EC%B2%A9%EB%90%9C-%EB%9D%BC%EB%B2%A8%EB%93%A4)
   - [교활한 `try..catch`](#%EA%B5%90%ED%99%9C%ED%95%9C-trycatch)
@@ -104,7 +104,7 @@ $ npm install -g wtfjs
   - [`null`과 `0` 비교](#null%EA%B3%BC-0-%EB%B9%84%EA%B5%90)
   - [동일한 변수 재선언](#%EB%8F%99%EC%9D%BC%ED%95%9C-%EB%B3%80%EC%88%98-%EC%9E%AC%EC%84%A0%EC%96%B8)
   - [디폴트 동작 Array.prototype.sort()](#%EB%94%94%ED%8F%B4%ED%8A%B8-%EB%8F%99%EC%9E%91-arrayprototypesort)
-  - [resolve()은 Promise instance 를 반환하지 않는다](#resolve%EC%9D%80-promise-instance-%EB%A5%BC-%EB%B0%98%ED%99%98%ED%95%98%EC%A7%80-%EC%95%8A%EB%8A%94%EB%8B%A4)
+  - [resolve()은 Promise instance를 반환하지 않는다](#resolve%EC%9D%80-promise-instance%EB%A5%BC-%EB%B0%98%ED%99%98%ED%95%98%EC%A7%80-%EC%95%8A%EB%8A%94%EB%8B%A4)
 - [📚 기타 resources](#-%EA%B8%B0%ED%83%80-resources)
 - [🎓 License](#-license)
 
@@ -115,13 +115,13 @@ $ npm install -g wtfjs
 
 > &mdash; _[**“Just for Fun: 우연한 혁명가의 이야기”**](https://en.wikipedia.org/wiki/Just_for_Fun), Linus Torvalds_
 
-이 목록의 주요 목표는 가능한 JavaScript 의 몇 가지의 엄청난 예들을 모으고, 작동 방식을 설명하는 것 입니다. 이전에 우리가 몰랐던 것들을 배우는 것이 재미 있기 때문입니다.
+이 목록의 주요 목표는 가능한 JavaScript의 몇 가지의 엄청난 예제들을 모으고, 작동 방식을 설명하는 것 입니다. 이전에 우리가 몰랐던 것들을 배우는 것이 재미있기 때문입니다.
 
-당신이 초보자라면, 이 노트를 사용하여 JavaScript 에 대해 자세히 알아 볼 수 있을 것입니다. 이 노트의 설명을 읽는 것에 더 많은 시간을 할애할수 있기를 바랍니다.
+당신이 초보자라면, 이 노트를 사용하여 JavaScript에 대해 자세히 알아볼 수 있을 것입니다. 이 노트의 설명을 읽는 것에 더 많은 시간을 할애할 수 있기를 바랍니다.
 
-당신이 전문 개발자라면, 우리가 사랑하는 JavaScript 의 모든 기이한 점과 예상치 못한 것들에 대한 예시에 훌륭한 참조로 간주 할 수 있습니다.
+당신이 전문 개발자라면, 우리가 사랑하는 JavaScript의 모든 기이한 점과 예상치 못한 것들에 대한 예시에 훌륭한 참조로 간주할 수 있습니다.
 
-어쨌든, 이것을 읽읍시다. 당신은 아마 새로운 것들을 찾을 수 있을 것 입니다.
+어쨌든, 이것을 읽읍시다. 당신은 아마 새로운 것들을 찾을 수 있을 것입니다.
 
 # ✍🏻 표기법
 
@@ -137,7 +137,7 @@ $ npm install -g wtfjs
 console.log("hello, world!"); // > hello, world!
 ```
 
-**`//`** 설명에 사용되는 주석입니다. 예:
+**`//`** 설명에 사용되는 주석입니다. 예를 들면:
 
 ```js
 // Assigning a function to foo constant
@@ -148,7 +148,7 @@ const foo = function() {};
 
 ## `[]`와 `![]은 같다`
 
-배열은 배열이 아닙니다.:
+배열은 배열이 아닙니다:
 
 ```js
 [] == ![]; // -> true
@@ -156,9 +156,9 @@ const foo = function() {};
 
 ### 💡 설명:
 
-추상 항등 연산자는 양쪽을 숫자로 변환하여 비교하고, 서로 다른 이유로 양 쪽의 숫자는 `0`이 됩니다. 배열은 truthy 하므로, 오른쪽의 값은 `0`을 강요하는 truthy value 의 반대 값 즉, `false`입니다. 그러나 왼쪽은 빈 배열은 먼저 boolean 되지 않고 숫자로 강제 변환되고 빈 배열은 truthy 임에도 불구하고`0`으로 강요됩니다.
+추상 항등 연산자는 양쪽을 숫자로 변환하여 비교하고, 서로 다른 이유로 양 쪽의 숫자는 `0`이 됩니다. 배열은 truthy 하므로, 오른쪽의 값은 `0`을 강요하는 truthy value의 반대 값 즉, `false`입니다. 그러나 왼쪽은 빈 배열은 먼저 boolean이 되지 않고 숫자로 강제 변환되고 빈 배열은 truthy 임에도 불구하고 `0`으로 강요됩니다.
 
-이 표현식이 어떻게 단순화 되는지는 아래와 같습니다.:
+이 표현식이 어떻게 단순화 되는지는 아래와 같습니다:
 
 ```js
 +[] == +![];
@@ -170,9 +170,9 @@ true;
 참조 [`[]`은 truthy 이지만 `true`은 아니다](#-is-truthy-but-not-true).
 
 - [**12.5.9** 논리 연산자 NOT (`!`)](https://www.ecma-international.org/ecma-262/#sec-logical-not-operator)
-- [**7.2.13** 추상 평등 ](https://www.ecma-international.org/ecma-262/#sec-abstract-equality-comparison)
+- [**7.2.13** 추상 평등](https://www.ecma-international.org/ecma-262/#sec-abstract-equality-comparison)
 
-## `true`는 `![]`와 같지 않지만, `[]` 이와도 같지 않다
+## `true`는 `![]`와 같지 않지만, `[]`와도 같지 않다
 
 배열은 `true`와 같지 않지만 배열이 아닌것도 `true`와 같지 않습니다;
 배열은 `false`와 같지만 배열이 아닌것도 `false`와 같습니다:
@@ -229,7 +229,7 @@ false == false; // -> true
 
 - [**7.2.13** 추상 평등 비교](https://www.ecma-international.org/ecma-262/#sec-abstract-equality-comparison)
 
-## true 은 false
+## true는 false
 
 ```js
 !!"false" == !!"true"; // -> true
@@ -258,7 +258,7 @@ false == "false"; // -> false
 "b" + "a" + +"a" + "a"; // -> 'baNaNa'
 ```
 
-이것은 JavaScript 에서 구식 농담이지만 재해석 되었습니다. 원본은 다음과 같습니다:
+이것은 JavaScript에서 구식 농담이지만 재해석 되었습니다. 원본은 다음과 같습니다:
 
 ```js
 "foo" + +"bar"; // -> 'fooNaN'
@@ -266,7 +266,7 @@ false == "false"; // -> false
 
 ### 💡 설명:
 
-식은 `'foo' + (+'bar')`으로 평가되고 숫자가 아닌 `'bar'`형태로 변환됩니다.
+식은 `'foo' + (+'bar')`으로 평가되고 숫자가 아닌 `'bar'` 형태로 변환됩니다.
 
 - [**12.8.3** 덧셈 연산자 (`+`)](https://www.ecma-international.org/ecma-262/#sec-addition-operator-plus)
 - [12.5.6 단항 + 연산자](https://www.ecma-international.org/ecma-262/#sec-unary-plus-operator)
@@ -289,11 +289,11 @@ NaN === NaN; // -> false
 >
 > &mdash; [**7.2.14** 염격한 평등 비교](https://www.ecma-international.org/ecma-262/#sec-strict-equality-comparison)
 
-IEEE 에서 정의한 `NaN`:
+IEEE에서 정의한 `NaN`:
 
-> 4 개의 상호 배타적인 관계 : 보다 작음, 같음, 보다 큼, 순서 없음. 마지막의 경우 하나 이상의 피연산자가 NaN 일 때 발생합니다. 모든 NaN 는 자신을 포함한 모든 것과 순서 없이 비교해야합니다.
+> 4 개의 상호 배타적인 관계 : 보다 작음, 같음, 보다 큼, 순서 없음. 마지막의 경우 하나 이상의 피연산자가 NaN일 때 발생합니다. 모든 NaN은 자신을 포함한 모든 것과 순서 없이 비교해야 합니다.
 >
-> &mdash; [“IEEE754 NaN 값에 false 를 반환하는 것의 근거는 무엇입니까?”](https://stackoverflow.com/questions/1565164/1573715#1573715) StackOverflow 에서
+> &mdash; [“IEEE754 NaN 값에 false를 반환하는 것의 근거는 무엇입니까?”](https://stackoverflow.com/questions/1565164/1573715#1573715) StackOverflow에서
 
 ## 이것은 실패다
 
@@ -322,7 +322,7 @@ IEEE 에서 정의한 `NaN`:
 ![] + [].toString(); // 'false'
 ```
 
-문자열을 배열로 생각하면 `[0]`을 통해 첫 번째 문자에 접근 할 수 있습니다:
+문자열을 배열로 생각하면 `[0]`을 통해 첫 번째 문자에 접근할 수 있습니다:
 
 ```js
 "false"[0]; // -> 'f'
@@ -368,7 +368,7 @@ null == false; // -> false
 
 - [**7.2.13** 추상 평등 비교](https://www.ecma-international.org/ecma-262/#sec-abstract-equality-comparison)
 
-## `document.all`은 객체이지만 `undefined` 이다
+## `document.all`은 객체이지만 `undefined`이다
 
 > ⚠️ 이 파트는 브라우저 API 의 일부이며 Node.js 환경에서는 작동하지 않습니다.⚠️
 
@@ -394,15 +394,15 @@ document.all == null; // -> true
 
 ### 💡 설명:
 
-> 특히 이전 버전의 IE 에서 `document.all`은 DOM 요소에 접근하는 방법을 사용했습니다. 이것은 표준이 된적은 없지만 이전 JS 코드에서 사용되었습니다. 새로운 APIs (`document.getElementById`와 같은)에서 표준이 진행되었을 때 이 API 호출은 쓸모 없게 되었고 표준 위원회는 이를 어떻게 처리할지 결정해야했습니다. 광범위하게 사용되기 때문에 그들은 API 를 유지하기로 결정했지만 JavaScript 명세된 것을 고의로 위반했습니다.
+> 특히 이전 버전의 IE에서 `document.all`은 DOM 요소에 접근하는 방법을 사용했습니다. 이것은 표준이 된 적은 없지만 이전 JavaScript 코드에서 사용되었습니다. 새로운 APIs(`document.getElementById`와 같은)에서 표준이 진행되었을 때 이 API 호출은 쓸모 없게 되었고 표준 위원회는 이를 어떻게 처리할지 결정해야 했습니다. 광범위하게 사용되기 때문에 그들은 API를 유지하기로 결정했지만 JavaScript 명세된 것을 고의로 위반했습니다.
 > 이것이 `undefined`의 상황에서 [엄격한 평등 비교](https://www.ecma-international.org/ecma-262/#sec-strict-equality-comparison)을 사용했을 때 `false`를 응답하고 [추상 평등 비교](https://www.ecma-international.org/ecma-262/#sec-abstract-equality-comparison)을 사용할 때 `true`로 응답하는 이유는 명시적으로 허용하는 명세된 것의 의도적인 위반 때문입니다.
 >
-> &mdash; [“오래된 특징 - document.all”](https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-all) WhatWG 의 HTML 명세된 것
-> &mdash; [“Chapter 4 - ToBoolean - Falsy values”](https://github.com/getify/You-Dont-Know-JS/blob/0d79079b61dad953bbfde817a5893a49f7e889fb/types%20%26%20grammar/ch4.md#falsy-objects) YDKJS 의 Types & Grammar
+> &mdash; [“오래된 특징 - document.all”](https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-all) WhatWG의 HTML 명세된 것
+> &mdash; [“Chapter 4 - ToBoolean - Falsy values”](https://github.com/getify/You-Dont-Know-JS/blob/0d79079b61dad953bbfde817a5893a49f7e889fb/types%20%26%20grammar/ch4.md#falsy-objects) YDKJS의 Types & Grammar
 
 ## 최소 값은 0 보다 크다
 
-`Number.MIN_VALUE`은 0 보다 큰 가장 작은 숫자입니다.:
+`Number.MIN_VALUE`은 0 보다 큰 가장 작은 숫자입니다:
 
 ```js
 Number.MIN_VALUE > 0; // -> true
@@ -410,11 +410,11 @@ Number.MIN_VALUE > 0; // -> true
 
 ### 💡 설명:
 
-> `Number.MIN_VALUE`은 `5e-324`입니다. 즉, 부동 소수점 정밀도 내에서 표현할 수 있는 가장 작은 양수입니다. 이 말은 0 에 도달할 수 있는 가장 가까운 값이라는 의미 입니다. 이것은 소수가 제공할 수 있는 최상의 값이라고 정의 할 수 있습니다.
+> `Number.MIN_VALUE`은 `5e-324`입니다. 즉, 부동 소수점 정밀도 내에서 표현할 수 있는 가장 작은 양수입니다. 이 말은 0 에 도달할 수 있는 가장 가까운 값이라는 의미 입니다. 이것은 소수가 제공할 수 있는 최상의 값이라고 정의할 수 있습니다.
 >
 > 비록 엄격하게 실제로 숫자는 아니지만 전체적으로 가장 작은 값은 `Number.NEGATIVE_INFINITY`이라고 할 수 있습니다.
 >
-> &mdash; [“자바 스크립트에서 왜 `0`은 `Number.MIN_VALUE`보다 작습니까?”](https://stackoverflow.com/questions/26614728/why-is-0-less-than-number-min-value-in-javascript) StackOverflow 에서
+> &mdash; [“자바 스크립트에서 왜 `0`은 `Number.MIN_VALUE`보다 작습니까?”](https://stackoverflow.com/questions/26614728/why-is-0-less-than-number-min-value-in-javascript) StackOverflow에서
 
 - [**20.1.2.9** Number.MIN_VALUE](https://www.ecma-international.org/ecma-262/#sec-number.min_value)
 
@@ -448,7 +448,7 @@ new Foo() instanceof null;
 
 ### 💡 설명:
 
-연결이 발생합니다.차근차근 다음을 봅시다.:
+연결이 발생합니다.차근차근 다음을 봅시다:
 
 ```js
 [1, 2, 3] +
@@ -465,7 +465,7 @@ new Foo() instanceof null;
 
 ## 배열의 후행 쉼표
 
-4 개의 빈 배열을 만듭니다. 그럼에도 불구하고 후행 쉼표로 인해 세가지 , 요소가 있는 배열을 얻게 됩니다.:
+4 개의 빈 배열을 만듭니다. 그럼에도 불구하고 후행 쉼표로 인해 세가지 , 요소가 있는 배열을 얻게 됩니다:
 
 ```js
 let a = [, , ,];
@@ -477,11 +477,11 @@ a.toString(); // -> ',,'
 
 > **후행 쉼표** ("마지막 쉼표"라고도 함)는 JavaScript 에 새로운 요소, 매개 변수 또는 속성을 추가할 때 유용하게 사용할 수 있습니다. 만약 새 속성을 추가하려는 상황에서 이미 후행 쉼표를 사용하고 있는 경우 이전 마지막 줄을 수정하지 않고 새 줄을 추가할 수 있습니다. 이렇게 하면 버전 관리가 더 깔끔 해지고 코드 편집이 덜 번거로울 수 있습니다.
 >
-> &mdash; [후행 쉼표](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas) MDN 에서
+> &mdash; [후행 쉼표](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas) MDN에서
 
 ## 배열 평등은 몬스터
 
-배열 평등은 아래에서 볼 수 있듯 JS 에서는 몬스터입니다.:
+배열 평등은 아래에서 볼 수 있듯 JavaScript에서는 몬스터입니다:
 
 ```js
 [] == ''   // -> true
@@ -511,11 +511,11 @@ a.toString(); // -> ',,'
 
 ### 💡 설명:
 
-아래의 예제를 주의 깊게 살펴 보아야 합니다.! 이 동작은 [**7.2.13** 추상 동등 비교](https://www.ecma-international.org/ecma-262/#sec-abstract-equality-comparison)에 설명되어 있습니다.
+아래의 예제를 주의 깊게 살펴 보아야 합니다! 이 동작은 [**7.2.13** 추상 동등 비교](https://www.ecma-international.org/ecma-262/#sec-abstract-equality-comparison)에 설명되어 있습니다.
 
 ## `undefined`과 `Number`
 
-`Number`생성자에 인수를 전달하지 않으면 `0`값을 얻게 됩니다. 실제 인수가 없는 경우 `undefined`값이 형식 인수에 할당되기 때문에 인수가 없는 `Number`는 매개 변수 값으로 `undefined`을 사용합니다. 그러나 `undefined`을 통과하면 `NaN`을 얻을 수 있습니다.
+`Number`생성자에 인수를 전달하지 않으면 `0` 값을 얻게 됩니다. 실제 인수가 없는 경우 `undefined`값이 형식 인수에 할당되기 때문에 인수가 없는 `Number`는 매개 변수 값으로 `undefined`를 사용합니다. 그러나 `undefined`를 통과하면 `NaN`을 얻을 수 있습니다.
 
 ```js
 Number(); // -> 0
@@ -526,7 +526,7 @@ Number(undefined); // -> NaN
 
 명세된 것에 따르면:
 
-1. 함수의 호출로 인수가 전달되지 않은 경우 `n`은 `+0`이 된다.
+1. 함수의 호출로 인수가 전달되지 않은 경우 `n`은 `+0`이 됩니다.
 2. 또는 let `n` be ? `ToNumber(value)`.
 3. `undefined`의 경우 `ToNumber(undefined)`는 `NaN`으로 반환해야 합니다.
 
@@ -544,7 +544,7 @@ parseInt("f*ck"); // -> NaN
 parseInt("f*ck", 16); // -> 15
 ```
 
-**💡 설명:** 이는 `parseInt`알 수 없는 문자에 도달 할 때까지 문자별로 계속 구문 분석을 하기 때문에 발생합니다. `'f*ck'`에서 `f`는 16 진수로 `15`입니다.
+**💡 설명:** 이는 `parseInt`알 수 없는 문자에 도달할 때까지 문자별로 계속 구문 분석을 하기 때문에 발생합니다. `'f*ck'`에서 `f`는 16 진수로 `15`입니다.
 
 `Infinity`정수로 파싱하는 것은…
 
@@ -575,9 +575,9 @@ parseInt(null, 24); // -> 23
 
 **💡 설명:**
 
-> `null`을 문자열`"null"`로 변환하려고 합니다. 0 부터 23 까지의 기수에 대해서 변환할 수 있는 숫자가 없으므로 NaN 을 반환합니다. 24 에, `"n"`, 14 번째 문자가 숫자 체계에 추가됩니다. 31 에, `"u"`, 21 번째 문자가 추가되고 전체 문자열을 디코딩 할 수 있게 되었습니다. 37 에서 더이상 생성할 수 있는 유효 숫자 집합이 없으며 `NaN`이 반환됩니다.
+> `null`을 문자열 `"null"`로 변환하려고 합니다. 0 부터 23 까지의 기수에 대해서 변환할 수 있는 숫자가 없으므로 NaN을 반환합니다. 24 에, `"n"`, 14 번째 문자가 숫자 체계에 추가됩니다. 31에, `"u"`, 21 번째 문자가 추가되고 전체 문자열을 디코딩 할 수 있게 되었습니다. 37에서 더 이상 생성할 수 있는 유효 숫자 집합이 없으며 `NaN`이 반환됩니다.
 >
-> &mdash; [“parseInt(null, 24) === 23… wait, what?”](https://stackoverflow.com/questions/6459758/parseintnull-24-23-wait-what) StackOverflow 에서
+> &mdash; [“parseInt(null, 24) === 23… wait, what?”](https://stackoverflow.com/questions/6459758/parseintnull-24-23-wait-what) StackOverflow에서
 
 8 진수에 대해서 잊지맙시다:
 
@@ -587,7 +587,7 @@ parseInt("08"); // 8 if support ECMAScript 5
 parseInt("08"); // 0 if not support ECMAScript 5
 ```
 
-**💡 설명:** 입력 문자열이 "0"으로 시작하는 경우, 기수는 8 (octal) 또는 10 (decimal)입니다. 정확히는 어떤 기수가 선택되는가는 구현에 따라 다릅니다. ECMAScript 5 은 10 (decimal)진수를 사용하도록 지정하지만 모든 브라우저가 이것을 지원하지는 않습니다. 그러므로 `parseInt`을 사용할 때는 항상 기수를 지정합시다.
+**💡 설명:** 입력 문자열이 "0"으로 시작하는 경우, 기수는 8 (octal) 또는 10 (decimal)입니다. 정확히는 어떤 기수가 선택되는가는 구현에 따라 다릅니다. ECMAScript 5는 10 (decimal)진수를 사용하도록 지정하지만 모든 브라우저가 이것을 지원하지는 않습니다. 그러므로 `parseInt`을 사용할 때는 항상 기수를 지정합시다.
 
 `parseInt`항상 입력을 문자열로 변환:
 
@@ -622,19 +622,19 @@ true -
 
 ### 💡 설명:
 
-`Number`생성자를 사용하여 값을 숫자로 강제 변환할 수 있습니다. `true`가 `1`로 강제되는 것은 분명합니다.:
+`Number`생성자를 사용하여 값을 숫자로 강제 변환할 수 있습니다. `true`가 `1`로 강제되는 것은 분명합니다:
 
 ```js
 Number(true); // -> 1
 ```
 
-단항 더하기 연산자는 값을 숫자로 변환하려고 합니다. 이것은 정수와 소수의 문자열 표현일 뿐아니라 비문자열인 `true`, `false`와 `null`값도 변환할 수 있습니다. 특정 값을 파싱할 수 없는 경우 `NaN`으로 평가됩니다. 그것은 더 쉽게 `true`를 `1`로 강제할 수 있음을 의미합니다.:
+단항 더하기 연산자는 값을 숫자로 변환하려고 합니다. 이것은 정수와 소수의 문자열 표현일 뿐아니라 비문자열인 `true`, `false`와 `null`값도 변환할 수 있습니다. 특정 값을 파싱할 수 없는 경우 `NaN`으로 평가됩니다. 그것은 더 쉽게 `true`를 `1`로 강제할 수 있음을 의미합니다:
 
 ```js
 +true; // -> 1
 ```
 
-덧셈 또는 곱셈을 수행할 때 `ToNumber`메서드가 호출됩니다. 명세된 것에 따르면 아래의 메서드를 반환합니다.:
+덧셈 또는 곱셈을 수행할 때 `ToNumber`메서드가 호출됩니다. 명세된 것에 따르면 아래의 메서드를 반환합니다:
 
 > 만약 `argument`이 **true**이면 **1**이 반환됩니다. 만약`argument`이 **false**이면 **+0**이 반환됩니다.
 
@@ -646,9 +646,9 @@ Number(true); // -> 1
 - [**12.8.3** 더하기 연산자(`+`)](https://www.ecma-international.org/ecma-262/#sec-addition-operator-plus)
 - [**7.1.3** ToNumber(`argument`)](https://www.ecma-international.org/ecma-262/#sec-tonumber)
 
-## HTML 주석은 JavaScript 에서도 유효하다
+## HTML 주석은 JavaScript에서도 유효하다
 
-이것이 `<!--` (HTML 주석으로 알려진) JavaScript 에서도 주석으로 사용될 수 있다는 것이 깊은 인상을 남깁니다.
+이것이 `<!--` (HTML 주석으로 알려진) JavaScript에서도 주석으로 사용될 수 있다는 것이 깊은 인상을 남깁니다.
 
 ```js
 // valid comment
@@ -657,9 +657,9 @@ Number(true); // -> 1
 
 ### 💡 설명:
 
-인상 깊었나요? 이는 HTML 과 유사한 주석 `<script>`태그를 이해하지 못하는 브라우저가 정상적으로 저하되도록 하기 위한것 입니다. Netscape 1.x 와 같은 브라우저는 더이상 인기가 없습니다. 따라서 더이상 스크립트 태그에 HTML 주석을 넣을 필요가 없습니다.
+인상 깊었나요? 이는 HTML 과 유사한 주석 `<script>` 태그를 이해하지 못하는 브라우저가 정상적으로 저하되도록 하기 위한 것 입니다. Netscape 1.x과 같은 브라우저는 더 이상 인기가 없습니다. 따라서 더 이상 스크립트 태그에 HTML 주석을 넣을 필요가 없습니다.
 
-Node.js 은 V8 엔진을 기반으로 하기때문에 Node.js 런타임에서도 HTML 과 유사한 주석을 지원합니다. 또한 그것은 명시된 것의 일부입니다:
+Node.js는 V8 엔진을 기반으로 하기때문에 Node.js 런타임에서도 HTML 과 유사한 주석을 지원합니다. 또한 그것은 명시된 것의 일부입니다:
 
 - [**B.1.3** HTML-like Comments](https://www.ecma-international.org/ecma-262/#sec-html-like-comments)
 
@@ -742,7 +742,7 @@ Object.prototype.toString.call(null);
 
 ### 💡 설명:
 
-[”부동 소수점 수학이 깨졌습니까?”](https://stackoverflow.com/questions/588004/is-floating-point-math-broken)에 대한 대답 StackOverflow 에서:
+[”부동 소수점 수학이 깨졌습니까?”](https://stackoverflow.com/questions/588004/is-floating-point-math-broken)에 대한 대답 StackOverflow에서:
 
 > 프로그램에서 상수 `0.2`와 `0.3`은 실제 값에 대한 근사치가 됩니다. `0.2`에 가장 가까운 `double`이 유리수 `0.2`보다 크지만 `0.3`에 가장 가까운 `double`이 유리수 `0.3`보다 작습니다. `0.1`과 `0.2`의 합은 유리수 `0.3`보다 커지기 때문에 코드의 상수와 일치하지 않습니다.
 
@@ -769,7 +769,7 @@ Number.prototype.isOne = function() {
 
 ### 💡 설명:
 
-분명히,`Number`객체를 JavaScript 에서 다른 객체처럼 확장할 수 있습니다. 그러나, 정의된 메서드의 동작이 명시된 것의 일부가 아닌 경우 권장되지 않습니다. `Number`의 속성 목록은 다음과 같습니다:
+분명히, `Number`객체를 JavaScript에서 다른 객체처럼 확장할 수 있습니다. 그러나, 정의된 메서드의 동작이 명시된 것의 일부가 아닌 경우 권장되지 않습니다. `Number`의 속성 목록은 다음과 같습니다:
 
 - [**20.1** 숫자 객체](https://www.ecma-international.org/ecma-262/#sec-number-objects)
 
@@ -806,7 +806,7 @@ true > 1; // true -> 1
 
 ## 재미있는 수학
 
-종종 JavaScript 에서 산술 연산 결과는 예상치 못한 결과일 수 있습니다. 아래의 예들을 고려합시다:
+종종 JavaScript에서 산술 연산 결과는 예상치 못한 결과일 수 있습니다. 아래의 예들을 고려합시다:
 
 ```js
  3  - 1  // -> 2
@@ -829,7 +829,7 @@ true > 1; // true -> 1
 
 ### 💡 설명:
 
-처음 4 가지 예시에서 무슨 일이 일어나고 있나요? JavaScript 에서 덧셈을 이해하기 위한 작은 표 입니다.:
+처음 4 가지 예시에서 무슨 일이 일어나고 있나요? JavaScript에서 덧셈을 이해하기 위한 작은 표 입니다:
 
 ```
 Number  + Number  -> addition
@@ -840,13 +840,13 @@ String  + Boolean -> concatenation
 String  + String  -> concatenation
 ```
 
-다른 예들을 추가하면 어떨까요? `ToPrimitive`과 `ToString` 메서드는 덧셈을 하기 전 `[]`과 `{}`을 암시적으로 요구합니다. 아래의 명시를 통해 평가 프로세스에 대해 자세히 알아봅시다.:
+다른 예들을 추가하면 어떨까요? `ToPrimitive`과 `ToString` 메서드는 덧셈을 하기 전 `[]`과 `{}`을 암시적으로 요구합니다. 아래의 명시를 통해 평가 프로세스에 대해 자세히 알아봅시다:
 
 - [**12.8.3** 더하기 연산자 (`+`)](https://www.ecma-international.org/ecma-262/#sec-addition-operator-plus)
 - [**7.1.1** ToPrimitive(`input` [,`PreferredType`])](https://www.ecma-international.org/ecma-262/#sec-toprimitive)
 - [**7.1.12** ToString(`argument`)](https://www.ecma-international.org/ecma-262/#sec-tostring)
 
-특히, `{} + []` 여기에 예외가 있습니다. `[] + {}`는 괄호가 없으면 코드 블록으로 해석한 다음 단항 +로 해석되어 `[]`숫자로 변환하기 때문입니다. 다음을 따릅니다.:
+특히, `{} + []` 여기에 예외가 있습니다. `[] + {}`는 괄호가 없으면 코드 블록으로 해석한 다음 단항 +로 해석되어 `[]`숫자로 변환하기 때문입니다. 다음을 따릅니다:
 
 ```js
 {
@@ -914,9 +914,9 @@ new String("str"); // -> [String: 'str']
 
 - [**21.1.1** 문자열 생성자](https://www.ecma-international.org/ecma-262/#sec-string-constructor)
 
-## backticks 으로 함수 호출
+## backticks으로 함수 호출
 
-모든 매개 변수를 콘솔에 기록하는 함수를 선언해 보겠습니다.:
+모든 매개 변수를 콘솔에 기록하는 함수를 선언해 보겠습니다:
 
 ```js
 function f(...args) {
@@ -924,13 +924,13 @@ function f(...args) {
 }
 ```
 
-의심할 여지없이 함수를 다음과 같이 호출할 수 있습니다.:
+의심할 여지없이 함수를 다음과 같이 호출할 수 있습니다:
 
 ```js
 f(1, 2, 3); // -> [ 1, 2, 3 ]
 ```
 
-그러나 backticks 을 사용하여 모든 함수를 호출 할 수 있다는 것을 알고있나요?
+그러나 backticks를 사용하여 모든 함수를 호출할 수 있다는 것을 알고있나요?
 
 ```js
 f`true is ${true}, false is ${false}, array is ${[1, 2, 3]}`;
@@ -950,7 +950,7 @@ function template(strings, ...keys) {
 }
 ```
 
-이 [magic behind](http://mxstbr.blog/2016/11/styled-components-magic-explained/)는 [💅 styled-components](https://www.styled-components.com/)라 불리는 React community 에서 인기있는 유명한 도서관에 있습니다.
+이 [magic behind](http://mxstbr.blog/2016/11/styled-components-magic-explained/)는 [💅 styled-components](https://www.styled-components.com/)라 불리는 React community에서 인기있는 유명한 도서관에 있습니다.
 
 명세서를 링크합니다:
 
@@ -1019,7 +1019,7 @@ c[c][c]('console.log("WTF?")')(); // > WTF?
 
 왜 그렇게 작동할까요? 여기에서 _Computed property name_ 을 사용합니다. 이러한 대괄호 사이에 객체를 전달하면 객체를 문자열로 강제 변환하기 때문에 속성 키 `'[object Object]'`와 `{}`값을 얻습니다.
 
-다음과 같이 "대괄호 지옥"을 만들 수 있습니다.:
+다음과 같이 "대괄호 지옥"을 만들 수 있습니다:
 
 ```js
 ({ [{}]: { [{}]: {} } }[{}][{}]); // -> {}
@@ -1032,14 +1032,14 @@ c[c][c]('console.log("WTF?")')(); // > WTF?
 // }
 ```
 
-여기에서 객체 리터럴에 대해 자세히 알아보세요.:
+여기에서 객체 리터럴에 대해 자세히 알아보세요:
 
 - [Object initializer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) at MDN
 - [**12.2.6** Object Initializer](http://www.ecma-international.org/ecma-262/6.0/#sec-object-initializer)
 
 ## `__proto__`을 사용한 프로토 타입 접근
 
-아시다시피 primitives 에는 prototypes 이 없습니다. 그러나, `__proto__` primitives 에 대한 값을 얻으려고 한다면 다음과 같이 할 수 있습니다.:
+아시다시피 primitives 에는 prototypes 이 없습니다. 그러나, `__proto__` primitives 에 대한 값을 얻으려고 한다면 다음과 같이 할 수 있습니다:
 
 ```js
 (1).__proto__.__proto__.__proto__; // -> null
@@ -1047,7 +1047,7 @@ c[c][c]('console.log("WTF?")')(); // > WTF?
 
 ### 💡 설명:
 
-이것은 프로토타입이 없는 무언가가 `ToObject` 메소드를 사용하여 래퍼 객체로 래핑되기 때문에 발생합니다. 차근차근 살펴봅시다.:
+이것은 프로토타입이 없는 무언가가 `ToObject` 메소드를 사용하여 래퍼 객체로 래핑되기 때문에 발생합니다. 차근차근 살펴봅시다:
 
 ```js
 (1)
@@ -1082,7 +1082,7 @@ c[c][c]('console.log("WTF?")')(); // > WTF?
 
 ### 💡 설명:
 
-_Shorthand property notation_ 을 `Object` 사용하여 속성이 있는 객체를 정의했습니다.:
+_Shorthand property notation_ 을 `Object` 사용하여 속성이 있는 객체를 정의했습니다:
 
 ```js
 {
@@ -1130,7 +1130,7 @@ y;
 
 - [Object initializer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) at MDN
 
-## Dots 과 spreading
+## Dots와 spreading
 
 배열의 확산으로 흥미로운 예를 구성할 수 있습니다. 이를 고려하세요:
 
@@ -1140,7 +1140,7 @@ y;
 
 ### 💡 설명:
 
-왜 `3`일까요? [spread operator](http://www.ecma-international.org/ecma-262/6.0/#sec-array-initializer)을 사용할 때 `@@iterator`메소드가 호출되고 반환된 반복자는 반복할 값을 얻는데 사용됩니다. 문자열의 기본 이터레이터는 문자열을 문자로 확산합니다. 확산 후 이러한 문자를 배열로 압축합니다. 그런 다음 이 배열을 다시 확산하고 배열로 다시 압축합니다.
+왜 `3`일까요? [spread operator](http://www.ecma-international.org/ecma-262/6.0/#sec-array-initializer)을 사용할 때 `@@iterator`메소드가 호출되고 반환된 Iterator는 반복할 값을 얻는데 사용됩니다. 문자열의 기본 Iterator는 문자열을 문자로 확산합니다. 확산 후 이러한 문자를 배열로 압축합니다. 그런 다음 이 배열을 다시 확산하고 배열로 다시 압축합니다.
 
 문자열 `'...'`은 세 개의`.`로 구성되며 문자열의 길이는 `3`입니다.
 
@@ -1164,7 +1164,7 @@ y;
 
 ## 라벨
 
-JavaScript 에서 라벨에 대해 아는 프로그래머는 많지 않습니다. 라벨들은 꽤 재미있습니다.:
+JavaScript에서 라벨에 대해 아는 프로그래머는 많지 않습니다. 라벨들은 꽤 재미있습니다:
 
 ```js
 foo: {
@@ -1182,7 +1182,7 @@ foo: {
 라벨 되어있는 문장들은 `break` 또는 `continue`문과 함께 사용됩니다. 라벨을 사용하여 루프를 식별할 수 있고 `break` 또는 `continue`문을 사용해 프로그램이 루프를 중단해야 하는지 또는 실행을 계속해야 하는지에 대한 여부를 알 수 있습니다.
 위의 예를 보면 `foo`라는 라벨을 볼 수 있습니다. 그 뒤로 `console.log('first');`을 실행한 후 실행을 중단합니다.
 
-JavaScript 의 라벨에 대해 더 읽을거리:
+JavaScript의 라벨에 대해 더 읽을거리:
 
 - [**13.13** Labelled Statements](https://tc39.github.io/ecma262/#sec-labelled-statements)
 - [Labeled statements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label) at MDN
@@ -1240,7 +1240,7 @@ new class F extends (String, Array) {}(); // -> F []
 
 ## 스스로 생성되는 Generator
 
-스스로 생성되는 Generator 의 예를 살펴봅시다:
+스스로 생성되는 Generator의 예를 살펴봅시다:
 
 ```js
 (function* f() {
@@ -1319,7 +1319,7 @@ const foo = {
 };
 ```
 
-그리고 ES6 에서 축약 메소드 정의를 표준화하였습니다. 또한 클래스는 익명이 될 수 있습니다. 그래서 우리가 `: function`부분을 지우면 아래와 같은 결과 값을 얻을 것 입니다:
+그리고 ES6에서 축약 메소드 정의를 표준화하였습니다. 또한 클래스는 익명이 될 수 있습니다. 그래서 우리가 `: function`부분을 지우면 아래와 같은 결과 값을 얻을 것 입니다:
 
 ```js
 class {
@@ -1490,7 +1490,7 @@ f("a");
 })(); // -> { b: 10 }
 ```
 
-이는 대부분 줄 바꿈 뒤에 세미콜론을 자동으로 삽입하는 자동 세미콜론 삽입이라는 개념 때문입니다. 첫번째 예시에서 `return`문과 객체 리터럴 사이에 세미콜론이 삽입되어 있으므로 함수는 `undefined`을 반환하고 객체 리터럴은 평가되지 않습니다.
+이는 대부분 줄 바꿈 뒤에 세미콜론을 자동으로 삽입하는 자동 세미콜론 삽입이라는 개념 때문입니다. 첫번째 예시에서 `return`문과 객체 리터럴 사이에 세미콜론이 삽입되어 있으므로 함수는 `undefined`를 반환하고 객체 리터럴은 평가되지 않습니다.
 
 - [**11.9.1** Rules of Automatic Semicolon Insertion](https://www.ecma-international.org/ecma-262/#sec-rules-of-automatic-semicolon-insertion)
 - [**13.10** The `return` Statement](https://www.ecma-international.org/ecma-262/#sec-return-statement)
@@ -1508,11 +1508,11 @@ foo; // -> {n: 2}
 bar; // -> {n: 1, x: {n: 2}}
 ```
 
-오른쪽에서 왼쪽으로, `{n: 2}`이 foo 에 할당되어 있고 이 할당의 결과`{n: 2}`는 foo.x 에 할당되어 있다고 bar 는 foo 를 할당하고 있기 때문에 bar 은 `{n: 1, x: {n: 2}}`이다. 그런데 bar.x 가 아닌 반면에 foo.x 는 왜 정의되지 않은 것일까 ?
+오른쪽에서 왼쪽으로, `{n: 2}`이 foo에 할당되고, 이 할당의 결과`{n: 2}`는 foo.x 에 할당되어 있고, bar는 foo를 할당하고 있기 때문에 bar는 `{n: 1, x: {n: 2}}`입니다. 그런데 bar.x가 아닌 반면에 foo.x는 왜 정의되지 않은 것일까요?
 
 ### 💡 설명:
 
-Foo 와 bar 는 같은 객체 `{n: 1}`를 참조하고 있고 lvalues 은 할당되기 전에 결정됩니다. `foo = {n: 2}`은 새로운 객체를 생성하고 있으므로 foo 는 새로운 객체를 참조하도록 업데이트됩니다. 트릭은 `foo.x = ...`의 foo 에 있습니다. lvalue 값은 사전에 확인되었고 여전히 이전 `foo = {n:1}` 객체를 참조하고 x 값을 추가하여 업데이트합니다. 체인 할당 후에도 bar 는 여전히 이전의 foo 객체를 참조하지만 foo 는 x 가 존재하지 않는 새로운 `{n: 2}`객체를 참조합니다.
+Foo와 bar는 같은 객체 `{n: 1}`를 참조하고 있고 lvalues는 할당되기 전에 결정됩니다. `foo = {n: 2}`은 새로운 객체를 생성하고 있으므로 foo는 새로운 객체를 참조하도록 업데이트됩니다. 트릭은 `foo.x = ...`의 foo 에 있습니다. lvalue 값은 사전에 확인되었고 여전히 이전 `foo = {n:1}` 객체를 참조하고 x 값을 추가하여 업데이트합니다. 체인 할당 후에도 bar는 여전히 이전의 foo 객체를 참조하지만 foo는 x가 존재하지 않는 새로운 `{n: 2}`객체를 참조합니다.
 
 다음과 동일합니다:
 
@@ -1552,7 +1552,7 @@ map["11,2,3"]; // -> true
 
 ### 💡 설명:
 
-대괄호 연산자`[]`는 `toString`을 사용하여 전달된 식을 변환합니다. 단일 요소 배열을 문자열으로 변환하는 것은 포함된 요소를 문자열로 변환하는 것과 유사합니다:
+대괄호 연산자 `[]`는 `toString`을 사용하여 전달된 식을 변환합니다. 단일 요소 배열을 문자열으로 변환하는 것은 포함된 요소를 문자열로 변환하는 것과 유사합니다:
 
 ```js
 ["property"].toString(); // -> 'property'
@@ -1569,11 +1569,11 @@ null >= 0; // true
 
 ### 💡 설명:
 
-긴 얘기를 짧게 하자면 만약 `null`이 `0` 보다 작으면 `false`이고 `null >= 0`은 `true`이다. 여기에서 이에 대한 자세한 설명을 읽으십시오 [여기](https://blog.campvanilla.com/javascript-the-curious-case-of-null-0-7b131644e274).
+긴 얘기를 짧게 하자면, 만약 `null`이 `0` 보다 작으면 `false`이고 `null >= 0`은 `true`입니다. 여기에서 이에 대한 자세한 설명을 읽으십시오 [여기](https://blog.campvanilla.com/javascript-the-curious-case-of-null-0-7b131644e274).
 
 ## `Number.toFixed()` 다른 숫자 표시
 
-`Number.toFixed()`은 다른 부라우저에서 약간 이상하게 작동할 수 있습니다. 아래 예를 확인하세요:
+`Number.toFixed()`는 다른 브라우저에서 약간 이상하게 작동할 수 있습니다. 아래 예를 확인하세요:
 
 ```js
 (0.7875).toFixed(3);
@@ -1588,7 +1588,7 @@ null >= 0; // true
 
 ### 💡 설명:
 
-본능적으로 IE11 은 올바르고 Firefox/Chrome 이 잘못되었다고 생각할 수 있지만 사실은 Firefox/Chrome 이 더 직접적으로 숫자의 표준(IEEE-754 Floating Point)을 준수하고 있는 반면 IE11 는 더 명확한 결과를 제공하기 위한 노력으로 그것들을 미세하게 거역하고 있습니다.
+본능적으로 IE11은 올바르고 Firefox/Chrome이 잘못되었다고 생각할 수 있지만 사실은 Firefox/Chrome이 더 직접적으로 숫자의 표준(IEEE-754 Floating Point)을 준수하고 있는 반면 IE11는 더 명확한 결과를 제공하기 위한 노력으로 그것들을 미세하게 거역하고 있습니다.
 
 몇 가지 간단한 테스트를 통해 이 문제가 발생하는 이유를 확인할 수 있습니다:
 
@@ -1602,11 +1602,11 @@ null >= 0; // true
 (0.7875).toFixed(20); // -> 0.78749999999999997780
 ```
 
-부동 소수점 번호는 내부적으로 10 진수 리스트로 저장되는 것이 아니라 대게 toString 과 유사한 호출에 의해 반올림되지만 실제로 내부적으로는 매우 복잡한 방법론을 통해 저장됩니다.
+부동 소수점 번호는 내부적으로 10진수 리스트로 저장되는 것이 아니라 대게 toString과 유사한 호출에 의해 반올림되지만 실제로 내부적으로는 매우 복잡한 방법론을 통해 저장됩니다.
 
-이 경우 끝에 있는 "5"는 실제로 진짜 5 보다 매우 작은 부분입니다.합리적인 길이로 반올림하면 5...로 렌더링되지만 실제로는 내부적으로 5 는 아닙니다.
+이 경우 끝에 있는 "5"는 실제로 진짜 5 보다 매우 작은 부분입니다.합리적인 길이로 반올림하면 5...으로 렌더링되지만 실제로는 내부적으로 5는 아닙니다.
 
-그러나 IE11 은 하드웨어 한계에서 문제를 줄이기 위해 값을 강제로 반올림하는 것처럼 보이기 때문에 toFixed(20)의 사례에서도 끝에 0 만 추가한 값을 입력 보고 할 것입니다.
+그러나 IE11은 하드웨어 한계에서 문제를 줄이기 위해 값을 강제로 반올림하는 것처럼 보이기 때문에 toFixed(20)의 사례에서도 끝에 0만 추가한 값을 입력 보고 할 것입니다.
 
 `toFixed`에 대한 ECMA-262 정의의 `NOTE 2`를 참고하세요.
 
@@ -1651,7 +1651,7 @@ null >= 0; // -> true
 true;
 ```
 
-그러나 spec 을 자세히 읽어보면 숫자 변환은 `null` 나 `undefined`의 한 면에서는 일어나지 않습니다. 그러므로 등호 한쪽에 `null`이 있으면 다른 한쪽에 `null` 또는 `undefined`가 있어야 `true`를 리턴한다. 이 경우 그렇지 않기 때문에`false`을 리턴한다.
+그러나 spec을 자세히 읽어보면 숫자 변환은 `null`이나 `undefined`의 한 면에서는 일어나지 않습니다. 그러므로 등호 한쪽에 `null`이 있으면 다른 한쪽에 `null` 또는 `undefined`가 있어야 `true`를 리턴합니다. 이 경우 그렇지 않기 때문에`false`을 리턴합니다.
 
 다음은 관계 비교 `null > 0`입나다. 여기서 알고리즘은 추상 평등 연산자와 달리 `null`을 숫자로 변환합니다. 따라서 다음과 같은 동작이 발생합니다:
 
@@ -1677,7 +1677,7 @@ true;
 
 ## 동일한 변수 재선언
 
-JS 에서는 변수를 다시 선언할 수 있습니다:
+JavaScript에서는 변수를 다시 선언할 수 있습니다:
 
 ```js
 a;
@@ -1686,7 +1686,7 @@ a;
 a, a;
 ```
 
-엄격한 모드에서도 작동합니다:
+strict 모드에서도 작동합니다:
 
 ```js
 var a, a, a;
@@ -1702,7 +1702,7 @@ var a;
 
 ## 디폴트 동작 Array.prototype.sort()
 
-숫자 배열을 정렬해야한다고 상상해보세요.
+숫자 배열을 정렬해야 한다고 상상해보세요.
 
 ```
 [ 10, 1, 3 ].sort() // -> [ 1, 10, 3 ]
@@ -1722,7 +1722,7 @@ var a;
 [ 10, 1, 3 ].sort((a, b) => a - b) // -> [ 1, 3, 10 ]
 ```
 
-## resolve()은 Promise instance 를 반환하지 않는다
+## resolve()은 Promise instance를 반환하지 않는다
 
 ```javascript
 const theObject = {
@@ -1758,7 +1758,7 @@ thePromise.then(value => {
 
 ### 💡 설명:
 
-> 이 함수는 promise 같은 객체의 중첩된 레이어(예 : 무언가로 해결되는 proomise 으로 해결되는 promise)를 단일 레이어로 평탄화합니다.
+> 이 함수는 promise 같은 객체의 중첩된 레이어(예시: 무언가로 해결되는 promise으로 해결되는 promise)를 단일 레이어로 평탄화합니다.
 
 &ndash; [Promise.resolve() on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve)
 


### PR DESCRIPTION
I recently found out that a Korean translation of wtfjs was created, and it was harder to read than I thought, as it was written by a non-native speaker, and the 'translation tone' seemed to remain. Therefore, I tried to make the translation easier to read by enhancing the translation a little bit more.

The major changes are as follows.
- When 'postposition'(like 은/는/이/가/을/를) is placed behind English words or English words wrapped in backticks, unnecessary spaces are removed.
- It is the same word, but the parts used differently depending on the location are modified.
- There were many problems with spacing, so they were corrected.
- The sentence ends awkwardly modified.
- Other grammatically correct typos or errors.